### PR TITLE
Simon Game Core Logic #7

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -10,4 +10,5 @@ words:
   - threlte
   - nipplejs
   - oncreate
+  - gameover
 ignorePaths: []

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	},
 	"name": "simon",
 	"private": true,
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
 	"type": "module",
 	"pnpm": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
 	webServer: { command: 'npm run build && npm run preview', port: 4173 },
-	testMatch: '**/*.e2e.{ts,js}'
+	testMatch: '**/*.e2e.{ts,js}',
+	workers: 1
 });

--- a/src/lib/game/SimonBoard.svelte
+++ b/src/lib/game/SimonBoard.svelte
@@ -1,11 +1,124 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
+	import { Text } from '@threlte/extras';
+	import { simon } from '$lib/simon/simon.svelte';
+	import type { ButtonColor } from '$lib/simon/types';
+	import { messages } from '$lib/messages/en';
+
+	const INNER_RADIUS = 0.3;
+	const OUTER_RADIUS = 0.7;
+	const THETA_SEGMENTS = 32;
+	const CIRCLE_SEGMENTS = 32;
+	const BACKING_SEGMENTS = 64;
+	const BUTTON_GAP = Math.PI / 36;
+	const THETA_START = BUTTON_GAP;
+	const THETA_LENGTH = Math.PI / 2 - BUTTON_GAP * 2;
+	const BACKING_RADIUS = 0.85;
+	const CENTER_RADIUS = 0.22;
+	const LABEL_Z = 0.02;
+	const BACKING_Z = -0.01;
+	const MODE_TOGGLE_Y = -1.0;
+	const MODE_BOX_W = 0.5;
+	const MODE_BOX_H = 0.12;
+	const MODE_BOX_D = 0.01;
+	const FONT_SIZE = 0.08;
+	const EMISSIVE_INTENSITY = 0.8;
+	const BOARD_Y = 1.2;
+	const BOARD_Z = -4.8;
+
+	interface ButtonConfig {
+		color: ButtonColor;
+		rotation: number;
+		lit_color: string;
+		dim_color: string;
+	}
+
+	const BUTTON_CONFIGS = [
+		{ color: 'green' as ButtonColor, rotation: 0, lit_color: '#00ff00', dim_color: '#003300' },
+		{
+			color: 'red' as ButtonColor,
+			rotation: Math.PI / 2,
+			lit_color: '#ff2222',
+			dim_color: '#330000'
+		},
+		{
+			color: 'yellow' as ButtonColor,
+			rotation: Math.PI,
+			lit_color: '#ffff00',
+			dim_color: '#333300'
+		},
+		{
+			color: 'blue' as ButtonColor,
+			rotation: -Math.PI / 2,
+			lit_color: '#2266ff',
+			dim_color: '#001133'
+		}
+	] as const satisfies readonly ButtonConfig[];
+
+	function is_lit(color: ButtonColor): boolean {
+		return simon.active_color === color || simon.pressed_color === color;
+	}
+
+	function on_press(color: ButtonColor): void {
+		simon.press(color);
+	}
+
+	function get_center_text(): string {
+		if (simon.phase === 'gameover') return messages.simon_gameover;
+		if (simon.round > 0) return `${messages.simon_round} ${simon.round}`;
+		return messages.simon_start;
+	}
+
+	function get_mode_text(): string {
+		return simon.mode === 'strict' ? messages.simon_strict : messages.simon_normal;
+	}
+
+	let center_text = $derived(get_center_text());
+	let mode_text = $derived(get_mode_text());
 </script>
 
-<!-- Simon board placeholder — replaced by full implementation in Issue #7 -->
-<T.Group position={[0, 1.2, -4.8]}>
-	<T.Mesh>
-		<T.BoxGeometry args={[1.5, 1.5, 0.1]} />
+<T.Group position={[0, BOARD_Y, BOARD_Z]}>
+	<T.Mesh position.z={BACKING_Z}>
+		<T.CircleGeometry args={[BACKING_RADIUS, BACKING_SEGMENTS]} />
+		<T.MeshStandardMaterial color="#111111" roughness={0.8} />
+	</T.Mesh>
+
+	{#each BUTTON_CONFIGS as btn (btn.color)}
+		<T.Group rotation.z={btn.rotation}>
+			<T.Mesh onclick={() => on_press(btn.color)}>
+				<T.RingGeometry
+					args={[INNER_RADIUS, OUTER_RADIUS, THETA_SEGMENTS, 1, THETA_START, THETA_LENGTH]}
+				/>
+				<T.MeshStandardMaterial
+					color={is_lit(btn.color) ? btn.lit_color : btn.dim_color}
+					emissive={is_lit(btn.color) ? btn.lit_color : '#000000'}
+					emissiveIntensity={EMISSIVE_INTENSITY}
+				/>
+			</T.Mesh>
+		</T.Group>
+	{/each}
+
+	<T.Mesh onclick={() => simon.start()}>
+		<T.CircleGeometry args={[CENTER_RADIUS, CIRCLE_SEGMENTS]} />
 		<T.MeshStandardMaterial color="#222222" roughness={0.5} />
 	</T.Mesh>
+
+	<T.Group position={[0, 0, LABEL_Z]}>
+		<Text
+			text={center_text}
+			fontSize={FONT_SIZE}
+			color="#ffffff"
+			anchorX="center"
+			anchorY="middle"
+		/>
+	</T.Group>
+
+	<T.Mesh position={[0, MODE_TOGGLE_Y, 0]} onclick={() => simon.toggle_mode()}>
+		<T.BoxGeometry args={[MODE_BOX_W, MODE_BOX_H, MODE_BOX_D]} />
+		<T.MeshStandardMaterial color="#333333" roughness={0.5} />
+	</T.Mesh>
+
+	<T.Group position={[0, MODE_TOGGLE_Y, LABEL_Z]}>
+		<Text text={mode_text} fontSize={FONT_SIZE} color="#aaaaaa" anchorX="center" anchorY="middle" />
+	</T.Group>
 </T.Group>

--- a/src/lib/messages/en.ts
+++ b/src/lib/messages/en.ts
@@ -2,5 +2,10 @@ export const messages = {
 	game_title: 'SIMON',
 	press_start: 'PRESS START',
 	cyber_switch_label: 'CYBER',
-	click_to_play: 'CLICK TO PLAY'
+	click_to_play: 'CLICK TO PLAY',
+	simon_start: 'START',
+	simon_round: 'ROUND',
+	simon_gameover: 'GAME OVER',
+	simon_strict: 'STRICT',
+	simon_normal: 'NORMAL'
 } as const;

--- a/src/lib/simon/audio.svelte.spec.ts
+++ b/src/lib/simon/audio.svelte.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { simon_audio } from '$lib/simon/audio';
+import type { ButtonColor } from '$lib/simon/types';
+
+const ALL_COLORS: ButtonColor[] = ['green', 'red', 'yellow', 'blue'];
+
+describe('simon audio', () => {
+	it.each(ALL_COLORS)('play_tone does not throw for %s', (color) => {
+		expect(() => simon_audio.play_tone(color, 100)).not.toThrow();
+	});
+});

--- a/src/lib/simon/audio.ts
+++ b/src/lib/simon/audio.ts
@@ -1,0 +1,32 @@
+import { audio as game_audio } from '$lib/game/audio';
+import type { ButtonColor } from './types';
+
+const FREQ: Record<ButtonColor, number> = {
+	green: 415,
+	red: 310,
+	yellow: 252,
+	blue: 209
+};
+
+const MS_PER_SECOND = 1000;
+const GAIN_VALUE = 0.5;
+const GAIN_FLOOR = 0.001;
+
+function play_tone(color: ButtonColor, duration_ms: number): void {
+	game_audio.init_audio();
+	const ctx = game_audio.get_audio_context();
+	if (!ctx) return;
+	const osc = ctx.createOscillator();
+	const gain = ctx.createGain();
+	osc.connect(gain);
+	gain.connect(ctx.destination);
+	osc.frequency.setValueAtTime(FREQ[color], ctx.currentTime);
+	osc.type = 'sine';
+	const duration_s = duration_ms / MS_PER_SECOND;
+	gain.gain.setValueAtTime(GAIN_VALUE, ctx.currentTime);
+	gain.gain.exponentialRampToValueAtTime(GAIN_FLOOR, ctx.currentTime + duration_s);
+	osc.start(ctx.currentTime);
+	osc.stop(ctx.currentTime + duration_s);
+}
+
+export const simon_audio = { play_tone };

--- a/src/lib/simon/simon.svelte.spec.ts
+++ b/src/lib/simon/simon.svelte.spec.ts
@@ -137,6 +137,18 @@ describe('simon FSM', () => {
 		expect(simon.round).toBe(0);
 	});
 
+	it('reset() cancels press feedback timer to prevent stale clear', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		const wrong = wrong_color(seq_at(0));
+		simon.press(wrong);
+		expect(simon.pressed_color).toBe(wrong);
+		simon.reset();
+		expect(simon.pressed_color).toBeNull();
+		await vi.advanceTimersByTimeAsync(PRESS_FEEDBACK_MS + 10);
+		expect(simon.phase).toBe('idle');
+	});
+
 	it('reset() cancels an in-progress sequence display', async () => {
 		simon.start();
 		simon.reset();

--- a/src/lib/simon/simon.svelte.spec.ts
+++ b/src/lib/simon/simon.svelte.spec.ts
@@ -1,0 +1,183 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { simon } from '$lib/simon/simon.svelte';
+import type { ButtonColor } from '$lib/simon/types';
+
+const ALL_COLORS: ButtonColor[] = ['green', 'red', 'yellow', 'blue'];
+const STEP_MS = 500;
+const ON_RATIO = 0.7;
+const OFF_RATIO = 0.3;
+const PRESS_FEEDBACK_MS = 200;
+const ON_MS = STEP_MS * ON_RATIO;
+const OFF_MS = STEP_MS * OFF_RATIO;
+
+function wrong_color(color: ButtonColor): ButtonColor {
+	return ALL_COLORS.find((c) => c !== color) ?? 'red';
+}
+
+function seq_at(i: number): ButtonColor {
+	const color = simon.sequence[i];
+	if (!color) throw new Error(`sequence index ${String(i)} out of range`);
+	return color;
+}
+
+describe('simon FSM', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		simon.reset();
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+		simon.reset();
+	});
+
+	it('starts in idle phase with empty sequence and round 0', () => {
+		expect(simon.phase).toBe('idle');
+		expect(simon.sequence).toHaveLength(0);
+		expect(simon.round).toBe(0);
+		expect(simon.active_color).toBeNull();
+		expect(simon.pressed_color).toBeNull();
+	});
+
+	it('start() transitions to showing, sets round 1, adds one sequence item', () => {
+		simon.start();
+		expect(simon.phase).toBe('showing');
+		expect(simon.round).toBe(1);
+		expect(simon.sequence).toHaveLength(1);
+	});
+
+	it('start() sets active_color to first sequence item immediately', () => {
+		simon.start();
+		expect(simon.active_color).toBe(seq_at(0));
+	});
+
+	it('showing phase transitions to player_input after timers complete', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		expect(simon.phase).toBe('player_input');
+		expect(simon.position).toBe(0);
+		expect(simon.active_color).toBeNull();
+	});
+
+	it('active_color clears after on_ms and phase becomes player_input after off_ms', async () => {
+		simon.start();
+		expect(simon.active_color).toBe(seq_at(0));
+		await vi.advanceTimersByTimeAsync(ON_MS);
+		expect(simon.active_color).toBeNull();
+		await vi.advanceTimersByTimeAsync(OFF_MS);
+		expect(simon.phase).toBe('player_input');
+	});
+
+	it('correct final press in round advances to next round showing', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.press(seq_at(0));
+		expect(simon.round).toBe(2);
+		expect(simon.sequence).toHaveLength(2);
+		expect(simon.phase).toBe('showing');
+	});
+
+	it('correct intermediate press advances position without completing round', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.press(seq_at(0)); // complete round 1
+		await vi.runAllTimersAsync(); // drain round 2 show
+		const first_color = seq_at(0);
+		simon.press(first_color); // first of two correct presses
+		expect(simon.position).toBe(1);
+		expect(simon.phase).toBe('player_input');
+		expect(simon.round).toBe(2);
+	});
+
+	it('wrong press in normal mode replays sequence then returns to player_input', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.press(wrong_color(seq_at(0)));
+		expect(simon.phase).toBe('showing');
+		await vi.runAllTimersAsync();
+		expect(simon.phase).toBe('player_input');
+		expect(simon.position).toBe(0);
+	});
+
+	it('wrong press in strict mode triggers gameover', async () => {
+		simon.toggle_mode();
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.press(wrong_color(seq_at(0)));
+		expect(simon.phase).toBe('gameover');
+	});
+
+	it('press() is ignored when not in player_input phase', () => {
+		simon.start(); // phase = showing
+		simon.press('green');
+		expect(simon.phase).toBe('showing');
+	});
+
+	it('pressed_color is set on press and clears after feedback duration', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		const color = seq_at(0);
+		simon.press(color);
+		expect(simon.pressed_color).toBe(color);
+		await vi.advanceTimersByTimeAsync(PRESS_FEEDBACK_MS);
+		expect(simon.pressed_color).toBeNull();
+	});
+
+	it('reset() returns all state to initial values', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.reset();
+		expect(simon.phase).toBe('idle');
+		expect(simon.mode).toBe('normal');
+		expect(simon.sequence).toHaveLength(0);
+		expect(simon.position).toBe(0);
+		expect(simon.active_color).toBeNull();
+		expect(simon.pressed_color).toBeNull();
+		expect(simon.round).toBe(0);
+	});
+
+	it('reset() cancels an in-progress sequence display', async () => {
+		simon.start();
+		simon.reset();
+		await vi.runAllTimersAsync();
+		expect(simon.phase).toBe('idle');
+	});
+
+	it('toggle_mode() switches from normal to strict', () => {
+		expect(simon.mode).toBe('normal');
+		simon.toggle_mode();
+		expect(simon.mode).toBe('strict');
+	});
+
+	it('toggle_mode() switches from strict back to normal', () => {
+		simon.toggle_mode();
+		simon.toggle_mode();
+		expect(simon.mode).toBe('normal');
+	});
+
+	it('start() from gameover restarts the game in the same mode', async () => {
+		simon.toggle_mode();
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.press(wrong_color(seq_at(0)));
+		expect(simon.phase).toBe('gameover');
+		simon.start();
+		expect(simon.phase).toBe('showing');
+		expect(simon.round).toBe(1);
+		expect(simon.mode).toBe('strict');
+	});
+
+	it('start() is ignored while showing', () => {
+		simon.start();
+		simon.start();
+		expect(simon.round).toBe(1);
+	});
+
+	it('start() is ignored during player_input', async () => {
+		simon.start();
+		await vi.runAllTimersAsync();
+		simon.start();
+		expect(simon.phase).toBe('player_input');
+	});
+});

--- a/src/lib/simon/simon.svelte.ts
+++ b/src/lib/simon/simon.svelte.ts
@@ -18,6 +18,7 @@ let active_color = $state<ButtonColor | null>(null);
 let pressed_color = $state<ButtonColor | null>(null);
 let round = $state(0);
 let show_gen = 0;
+let press_feedback_timer: ReturnType<typeof setTimeout> | null = null;
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -86,12 +87,24 @@ function start(): void {
 	void run_show(show_gen);
 }
 
+function schedule_press_feedback(): void {
+	if (press_feedback_timer !== null) clearTimeout(press_feedback_timer);
+	press_feedback_timer = setTimeout(() => {
+		pressed_color = null;
+		press_feedback_timer = null;
+	}, PRESS_FEEDBACK_MS);
+}
+
+function cancel_press_feedback(): void {
+	if (press_feedback_timer !== null) clearTimeout(press_feedback_timer);
+	press_feedback_timer = null;
+	pressed_color = null;
+}
+
 function press(color: ButtonColor): void {
 	if (phase !== 'player_input') return;
 	pressed_color = color;
-	setTimeout(() => {
-		pressed_color = null;
-	}, PRESS_FEEDBACK_MS);
+	schedule_press_feedback();
 	if (color === sequence[position]) {
 		handle_correct_press();
 	} else {
@@ -101,12 +114,12 @@ function press(color: ButtonColor): void {
 
 function reset(): void {
 	show_gen += 1;
+	cancel_press_feedback();
 	phase = 'idle';
 	mode = 'normal';
 	sequence = [];
 	position = 0;
 	active_color = null;
-	pressed_color = null;
 	round = 0;
 }
 

--- a/src/lib/simon/simon.svelte.ts
+++ b/src/lib/simon/simon.svelte.ts
@@ -1,0 +1,143 @@
+import { simon_audio } from './audio';
+import type { ButtonColor, SimonPhase, SimonMode } from './types';
+
+const COLORS: readonly ButtonColor[] = ['green', 'red', 'yellow', 'blue'];
+const STEP_MS_1_5 = 500;
+const STEP_MS_6_13 = 400;
+const STEP_MS_14_20 = 250;
+const STEP_MS_21_PLUS = 150;
+const ON_RATIO = 0.7;
+const OFF_RATIO = 0.3;
+const PRESS_FEEDBACK_MS = 200;
+
+let phase = $state<SimonPhase>('idle');
+let mode = $state<SimonMode>('normal');
+let sequence = $state<ButtonColor[]>([]);
+let position = $state(0);
+let active_color = $state<ButtonColor | null>(null);
+let pressed_color = $state<ButtonColor | null>(null);
+let round = $state(0);
+let show_gen = 0;
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function get_step_ms(len: number): number {
+	if (len <= 5) return STEP_MS_1_5;
+	if (len <= 13) return STEP_MS_6_13;
+	if (len <= 20) return STEP_MS_14_20;
+	return STEP_MS_21_PLUS;
+}
+
+function add_to_sequence(): void {
+	const index = Math.floor(Math.random() * COLORS.length);
+	const color = COLORS[index];
+	if (!color) return;
+	sequence.push(color);
+}
+
+async function run_show(gen: number): Promise<void> {
+	const step_ms = get_step_ms(sequence.length);
+	const on_ms = step_ms * ON_RATIO;
+	const off_ms = step_ms * OFF_RATIO;
+	for (const color of sequence) {
+		if (gen !== show_gen) return;
+		active_color = color;
+		simon_audio.play_tone(color, on_ms);
+		await delay(on_ms);
+		if (gen !== show_gen) return;
+		active_color = null;
+		await delay(off_ms);
+	}
+	if (gen !== show_gen) return;
+	phase = 'player_input';
+	position = 0;
+}
+
+function handle_correct_press(): void {
+	position += 1;
+	if (position < sequence.length) return;
+	round += 1;
+	add_to_sequence();
+	phase = 'showing';
+	show_gen += 1;
+	void run_show(show_gen);
+}
+
+function handle_wrong_press(): void {
+	if (mode === 'strict') {
+		phase = 'gameover';
+		return;
+	}
+	phase = 'showing';
+	show_gen += 1;
+	void run_show(show_gen);
+}
+
+function start(): void {
+	if (phase === 'showing') return;
+	if (phase === 'player_input') return;
+	phase = 'showing';
+	round = 1;
+	sequence = [];
+	add_to_sequence();
+	show_gen += 1;
+	void run_show(show_gen);
+}
+
+function press(color: ButtonColor): void {
+	if (phase !== 'player_input') return;
+	pressed_color = color;
+	setTimeout(() => {
+		pressed_color = null;
+	}, PRESS_FEEDBACK_MS);
+	if (color === sequence[position]) {
+		handle_correct_press();
+	} else {
+		handle_wrong_press();
+	}
+}
+
+function reset(): void {
+	show_gen += 1;
+	phase = 'idle';
+	mode = 'normal';
+	sequence = [];
+	position = 0;
+	active_color = null;
+	pressed_color = null;
+	round = 0;
+}
+
+function toggle_mode(): void {
+	mode = mode === 'normal' ? 'strict' : 'normal';
+}
+
+export const simon = {
+	get phase() {
+		return phase;
+	},
+	get mode() {
+		return mode;
+	},
+	get sequence() {
+		return sequence;
+	},
+	get position() {
+		return position;
+	},
+	get active_color() {
+		return active_color;
+	},
+	get pressed_color() {
+		return pressed_color;
+	},
+	get round() {
+		return round;
+	},
+	start,
+	press,
+	reset,
+	toggle_mode
+};

--- a/src/lib/simon/types.ts
+++ b/src/lib/simon/types.ts
@@ -1,0 +1,3 @@
+export type ButtonColor = 'green' | 'red' | 'yellow' | 'blue';
+export type SimonPhase = 'idle' | 'showing' | 'player_input' | 'gameover';
+export type SimonMode = 'normal' | 'strict';


### PR DESCRIPTION
## Summary
- Implement Simon game FSM singleton (`simon.svelte.ts`) with idle/showing/player_input/gameover phases, normal/strict modes, and cancellable async sequence display
- Add Simon button audio (`simon/audio.ts`) using Web Audio API with the original Simon frequencies (green=415Hz, red=310Hz, yellow=252Hz, blue=209Hz)
- Replace SimonBoard placeholder with a real 3D board: four RingGeometry arc sectors (green/red/yellow/blue), reactive lit/unlit states via emissive colors, center start button, and mode toggle button

## Test plan
- [ ] Run `pnpm josh test:unit` — 51 unit/browser tests pass (includes 22 new FSM and audio tests)
- [ ] Run `pnpm josh test` — E2E suite passes (title screen, game scene navigation)
- [ ] Manually start the game, approach Simon board, click buttons to verify visual feedback and sequence playback
- [ ] Verify audio tones play for each color button

🤖 Generated with [Claude Code](https://claude.com/claude-code)