### PR TITLE
Add HTTP security headers (CSP, X-Frame-Options, Referrer-Policy) to server hooks

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -36,6 +36,7 @@ words:
   - TAILWINDLABS
   - threlte
   - trycloudflare
+  - SAMEORIGIN
   - unstub
   - yoannmoinet
   - YOANNMOINET

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	},
 	"name": "simon",
 	"private": true,
-	"version": "0.77.0",
+	"version": "0.78.0",
 	"packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
 	"type": "module",
 	"pnpm": {

--- a/src/hooks.server.spec.ts
+++ b/src/hooks.server.spec.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { inject_version } from './hooks.server';
+import { describe, it, expect, vi } from 'vitest';
+import type { RequestEvent, ResolveOptions } from '@sveltejs/kit';
+import { inject_version, handle } from './hooks.server';
 import { readFileSync } from 'node:fs';
 
 const { version } = JSON.parse(
 	readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
 ) as { version: string };
+
+type ResolveFn = (event: RequestEvent, opts?: ResolveOptions) => Promise<Response>;
+
+function make_resolve(): ResolveFn {
+	return vi.fn<ResolveFn>().mockResolvedValue(new Response(null, { status: 200 }));
+}
 
 describe('inject_version', () => {
 	it('replaces the placeholder with the package version', () => {
@@ -20,5 +27,50 @@ describe('inject_version', () => {
 	it('passes through html that has no placeholder', () => {
 		const html = '<p>no placeholder here</p>';
 		expect(inject_version(html)).toBe(html);
+	});
+});
+
+describe('handle', () => {
+	it('adds X-Frame-Options: SAMEORIGIN', async () => {
+		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() });
+		expect(response.headers.get('x-frame-options')).toBe('SAMEORIGIN');
+	});
+
+	it('adds X-Content-Type-Options: nosniff', async () => {
+		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() });
+		expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+	});
+
+	it('adds Referrer-Policy: strict-origin-when-cross-origin', async () => {
+		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() });
+		expect(response.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin');
+	});
+
+	it('adds Permissions-Policy restricting camera, microphone, geolocation, payment', async () => {
+		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() });
+		const policy = response.headers.get('permissions-policy');
+		expect(policy).toContain('camera=()');
+		expect(policy).toContain('microphone=()');
+		expect(policy).toContain('geolocation=()');
+		expect(policy).toContain('payment=()');
+	});
+
+	it("adds Content-Security-Policy with default-src 'self'", async () => {
+		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() });
+		const csp = response.headers.get('content-security-policy');
+		expect(csp).toContain("default-src 'self'");
+		expect(csp).toContain("object-src 'none'");
+		expect(csp).toContain("frame-ancestors 'self'");
+	});
+
+	it('still injects app version via transformPageChunk', async () => {
+		let captured_transform: ResolveOptions['transformPageChunk'] | undefined;
+		const resolve = vi.fn<ResolveFn>().mockImplementation((_event, opts) => {
+			captured_transform = opts?.transformPageChunk;
+			return Promise.resolve(new Response(null, { status: 200 }));
+		});
+		await handle({ event: {} as RequestEvent, resolve });
+		const result = await captured_transform?.({ html: 'v__APP_VERSION__', done: true });
+		expect(result).toBe(`v${version}`);
 	});
 });

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,7 +4,7 @@ import { version } from '../package.json';
 const APP_VERSION_PLACEHOLDER = '__APP_VERSION__';
 const CSP_POLICY = [
 	"default-src 'self'",
-	"script-src 'self' 'unsafe-inline'",
+	"script-src 'self' 'unsafe-inline' blob:",
 	"style-src 'self' 'unsafe-inline'",
 	"img-src 'self' data: blob:",
 	"media-src 'self' blob:",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,15 +2,40 @@ import type { Handle } from '@sveltejs/kit';
 import { version } from '../package.json';
 
 const APP_VERSION_PLACEHOLDER = '__APP_VERSION__';
+const CSP_POLICY = [
+	"default-src 'self'",
+	"script-src 'self' 'unsafe-inline'",
+	"style-src 'self' 'unsafe-inline'",
+	"img-src 'self' data: blob:",
+	"media-src 'self' blob:",
+	"worker-src 'self' blob:",
+	"connect-src 'self'",
+	"font-src 'self'",
+	"object-src 'none'",
+	"base-uri 'self'",
+	"form-action 'self'",
+	"frame-ancestors 'self'"
+].join('; ');
+const PERMISSIONS_POLICY = 'camera=(), microphone=(), geolocation=(), payment=()';
 
 export function inject_version(html: string): string {
 	return html.replaceAll(APP_VERSION_PLACEHOLDER, version);
 }
 
+function inject_security_headers(response: Response): void {
+	response.headers.set('X-Frame-Options', 'SAMEORIGIN');
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	response.headers.set('Permissions-Policy', PERMISSIONS_POLICY);
+	response.headers.set('Content-Security-Policy', CSP_POLICY);
+}
+
 export const handle: Handle = async function handle({ event, resolve }) {
-	return resolve(event, {
+	const response = await resolve(event, {
 		transformPageChunk({ html }) {
 			return inject_version(html);
 		}
 	});
+	inject_security_headers(response);
+	return response;
 };

--- a/src/routes/page.e2e.ts
+++ b/src/routes/page.e2e.ts
@@ -35,6 +35,16 @@ async function stub_touch_primary(page: Page, is_touch: boolean): Promise<void> 
 	);
 }
 
+test('page response includes HTTP security headers', async ({ page }) => {
+	const response = await page.goto('/');
+	const headers = response?.headers() ?? {};
+	expect(headers['x-frame-options']).toBe('SAMEORIGIN');
+	expect(headers['x-content-type-options']).toBe('nosniff');
+	expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+	expect(headers['permissions-policy']).toContain('camera=()');
+	expect(headers['content-security-policy']).toContain("default-src 'self'");
+});
+
 test('game scene renders immediately with canvas', async ({ page }) => {
 	await page.goto('/');
 	await expect(page.locator('[data-testid="game-scene"]')).toBeVisible();


### PR DESCRIPTION
## Summary
- Add `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` response headers in `hooks.server.ts`
- Extract `inject_security_headers()` function
- Fix: `script-src` must include `blob:` for `troika-three-text` Web Worker `importScripts` to work (discovered during E2E testing)

## Test plan
- [x] Unit tests: 6 new tests in `hooks.server.spec.ts` verify each security header
- [x] E2E test: `page.e2e.ts` verifies headers are present in HTTP response
- [x] All 17 E2E tests pass (including CSP-sensitive scene loading tests)
- [x] 422 unit tests pass

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)