### PR TITLE
Fix browser tab favicon using Svelte logo instead of Simon icon #224

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "simon",
-	"version": "0.97.0",
+	"version": "0.98.0",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1497,11 +1497,6 @@ packages:
     peerDependencies:
       '@playwright/test': '>=1.0.0'
       svelte: '>=5.0.0'
-    peerDependenciesMeta:
-      '@playwright/test':
-        optional: true
-      svelte:
-        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -5681,13 +5676,12 @@ snapshots:
 
   '@joshuafolkken/kit@0.125.0(@playwright/test@1.59.1)(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
+      '@playwright/test': 1.59.1
       js-yaml: 4.1.1
       strip-json-comments: 5.0.3
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       tsx: 4.21.0
       zod: 4.4.2
-    optionalDependencies:
-      '@playwright/test': 1.59.1
-      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import './layout.css';
-	import favicon from '$lib/assets/favicon.svg';
 	import click_url from '$lib/assets/sound/dragon-studio-distorted-electronic-click-472367.opus';
 	import { loading, OVERLAY_ELEMENT_ID, OVERLAY_HIDDEN_CLASS } from '$lib/game/loading.svelte';
 	import { switch_audio } from '$lib/game/switch-audio';
@@ -41,6 +40,5 @@
 
 <svelte:head>
 	<title>{messages.game_title}</title>
-	<link rel="icon" href={favicon} />
 </svelte:head>
 {@render children()}

--- a/src/routes/page.e2e.ts
+++ b/src/routes/page.e2e.ts
@@ -311,6 +311,15 @@ test('game scene loads without shadow-related WebGL errors', async ({ page }) =>
 	expect(webgl_errors).toHaveLength(0);
 });
 
+test('favicon link points to the Simon icon, not the Svelte logo', async ({ page }) => {
+	await page.goto('/');
+	const icon_href = await page.evaluate(() => {
+		const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+		return link?.getAttribute('href') ?? null;
+	});
+	expect(icon_href).toBe('/icon.svg');
+});
+
 test('PWA manifest is linked in document head', async ({ page }) => {
 	await page.goto('/');
 	const manifest_href = await page.evaluate(() => {

--- a/src/routes/page.e2e.ts
+++ b/src/routes/page.e2e.ts
@@ -314,8 +314,9 @@ test('game scene loads without shadow-related WebGL errors', async ({ page }) =>
 test('favicon link points to the Simon icon, not the Svelte logo', async ({ page }) => {
 	await page.goto('/');
 	const icon_href = await page.evaluate(() => {
-		const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
-		return link?.getAttribute('href') ?? null;
+		const links = document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]');
+		const last = links[links.length - 1];
+		return last?.getAttribute('href') ?? null;
 	});
 	expect(icon_href).toBe('/icon.svg');
 });


### PR DESCRIPTION
closes #224